### PR TITLE
move api serverside

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,40 +13,37 @@ var api = phoenixAPI.init(sbot) // create plugin api instance
 // api.on('post', cb) // emitted on each new toplevel post
 // :TODO: replace this, maybe with a source stream
 
-api.getMyProfile(cb) // gets this user's profile
-
-api.getThreadMeta(key, cb) // gets metadata for the thread at the given key
-api.getAllThreadMetas(cb) // gets metadata for all threads in a key->meta map
-// metadata object: { parent:, replies: [keys], numThreadReplies: }
-
-api.getMsg(key, cb) // get message data
-api.getReplies(key, cb) // get replies to a message
-api.getPostParent(key, cb) // get parent post to a reply (null if none)
-api.getThread(key, cb) // get full thread (replies, replies to replies, etc)
-
 api.getFeed({ gt:, gte:, lt:, lte:, limit:, reverse: }, cb) // get raw messages. gt/e, lt/e can be message objects
+
 api.getPosts({ start:, end: }, cb) // get post messages. start/end are offsets
 api.getPostCount(cb) // get number of post messages
+
 api.getInbox({ start:, end: }, cb) // get post messages which reply to or mention the author. start/end are offsets
 api.getInboxCount(cb) // get number of post messages in the inbox
+
 api.getAdverts({ start:, end: }, cb) // get advert messages. start/end are offsets
 api.getAdvertCount(cb) // get number of adverts
 api.getRandomAdverts(num, oldest, cb) // get `num` adverts from the `oldest` most recent messages
-
-api.getProfile(id, cb) // gets profile
-api.getAllProfiles(cb) // gets all profiles in id->profile map
-api.getGraph(type, cb) // get friends graph (type may be 'follow', 'trust', or 'edge')
-api.getNamesById(cb) // gets map of id->names
-api.getName(id, cb) // gets name for the given id
-api.getIdsByName(cb) // gets map of names->id
 
 api.postText(text, cb) // publish post
 api.postReply(text, parentKey, cb) // publish reply
 api.postAdvert(text, cb) // publish advert
 
+api.getMsg(key, cb) // get message data
+api.getReplies(key, cb) // get replies to a message
+api.getPostParent(key, cb) // get parent post to a reply (null if none)
+api.getThread(key, cb) // get full thread (replies, replies to replies, etc)
+api.getThreadMeta(key, cb) // gets metadata for the thread at the given key
+api.getAllThreadMetas(cb) // gets metadata for all threads in a key->meta map
+// metadata object: { parent:, replies: [keys], numThreadReplies: }
+
+api.getMyProfile(cb) // gets this user's profile
+api.getProfile(id, cb) // gets profile
+api.getAllProfiles(cb) // gets all profiles in id->profile map
+
+api.getNamesById(cb) // gets map of id->names
+api.getName(id, cb) // gets name for the given id
+api.getIdsByName(cb) // gets map of names->id
 api.nameSelf(name, cb) // publish new name for self
 api.nameOther(target, name, cb) // publish new name for target
-
-api.addEdge(type, target, cb) // publish new edge from self to target (type may be 'follow', 'trust', or 'edge')
-api.delEdge(type, target, cb) // publish deleted edge from self to target (type may be 'follow', 'trust', or 'edge')
 ```

--- a/README.md
+++ b/README.md
@@ -1,57 +1,52 @@
 # Phoenix API
 
-methods for reading and writing to the log from the phoenix gui
+scuttlebot rpc methods for accessing the log from the phoenix gui
 
 ```js
-var api = require('phoenix-api')(ssbRpcApi)
+var phoenixAPI = require('phoenix-api')
 
-// initiate the indexing process
-// - call this any time the connection is created (eg on init, after disconnects)
-api.startIndexing(function (err) {
-  if (err)
-    throw err
+phoenixAPI.manifest    // rpc manifest
+phoenixAPI.permissions // rpc permissions
 
-  // get functions only work after startIndexing has called its cb
+var api = phoenixAPI.init(sbot) // create plugin api instance
 
-  api.on('post', cb) // emitted on each new toplevel post
+// api.on('post', cb) // emitted on each new toplevel post
+// :TODO: replace this, maybe with a source stream
 
-  api.getMyId() // returns this user's id
-  api.getMyProfile() // returns this user's profile
+api.getMyProfile(cb) // gets this user's profile
 
-  api.getMsg(key, cb) // get message data
-  api.getReplyCount(key) // returns # of replies to a message
-  api.getThreadReplyCount(key) // returns # of replies to a message's thread
-  api.getReplies(key, cb) // get replies to a message
-  api.getPostParent(key, cb) // get parent post to a reply (null if none)
-  api.getThread(key, cb) // get full thread (replies, replies to replies, etc)
+api.getThreadMeta(key, cb) // gets metadata for the thread at the given key
+api.getAllThreadMetas(cb) // gets metadata for all threads in a key->meta map
+// metadata object: { parent:, replies: [keys], numThreadReplies: }
 
-  api.getFeed({ gt:, gte:, lt:, lte:, limit:, reverse: }, cb) // get raw messages. gt/e, lt/e can be message objects
-  api.getPosts({ start:, end: }, cb) // get post messages. start/end are offsets
-  api.getPostCount() // get number of post messages
-  api.getInbox({ start:, end: }, cb) // get post messages which reply to or mention the author. start/end are offsets
-  api.getInboxCount() // get number of post messages in the inbox
-  api.getAdverts({ start:, end: }, cb) // get advert messages. start/end are offsets
-  api.getAdvertCount() // get number of adverts
-  api.getRandomAdverts(num, oldest, cb) // get `num` adverts from the `oldest` most recent messages
+api.getMsg(key, cb) // get message data
+api.getReplies(key, cb) // get replies to a message
+api.getPostParent(key, cb) // get parent post to a reply (null if none)
+api.getThread(key, cb) // get full thread (replies, replies to replies, etc)
 
-  api.getProfile(id) // returns profile
-  api.getAllProfiles() // returns all profiles in id->profile map
-  api.getGraph(type, cb) // get friends graph (type may be 'follow', 'trust', or 'edge')
-  api.getNames() // returns map of id->names
-  api.getName(id) // returns user's name
-  api.getNameById(id) // returns user's name
-  api.getIdByName(name) // returns user's id
+api.getFeed({ gt:, gte:, lt:, lte:, limit:, reverse: }, cb) // get raw messages. gt/e, lt/e can be message objects
+api.getPosts({ start:, end: }, cb) // get post messages. start/end are offsets
+api.getPostCount(cb) // get number of post messages
+api.getInbox({ start:, end: }, cb) // get post messages which reply to or mention the author. start/end are offsets
+api.getInboxCount(cb) // get number of post messages in the inbox
+api.getAdverts({ start:, end: }, cb) // get advert messages. start/end are offsets
+api.getAdvertCount(cb) // get number of adverts
+api.getRandomAdverts(num, oldest, cb) // get `num` adverts from the `oldest` most recent messages
 
-  api.postText(text, cb) // publish post
-  api.postReply(text, parentKey, cb) // publish reply
-  api.postAdvert(text, cb) // publish advert
+api.getProfile(id, cb) // gets profile
+api.getAllProfiles(cb) // gets all profiles in id->profile map
+api.getGraph(type, cb) // get friends graph (type may be 'follow', 'trust', or 'edge')
+api.getNamesById(cb) // gets map of id->names
+api.getName(id, cb) // gets name for the given id
+api.getIdsByName(cb) // gets map of names->id
 
-  api.nameSelf(name, cb) // publish new name for self
-  api.nameOther(target, name, cb) // publish new name for target
+api.postText(text, cb) // publish post
+api.postReply(text, parentKey, cb) // publish reply
+api.postAdvert(text, cb) // publish advert
 
-  api.addEdge(type, target, cb) // publish new edge from self to target (type may be 'follow', 'trust', or 'edge')
-  api.delEdge(type, target, cb) // publish deleted edge from self to target (type may be 'follow', 'trust', or 'edge')
+api.nameSelf(name, cb) // publish new name for self
+api.nameOther(target, name, cb) // publish new name for target
 
-  api.useInvite(invite, cb)
-})
+api.addEdge(type, target, cb) // publish new edge from self to target (type may be 'follow', 'trust', or 'edge')
+api.delEdge(type, target, cb) // publish deleted edge from self to target (type may be 'follow', 'trust', or 'edge')
 ```

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ phoenixAPI.permissions // rpc permissions
 
 var api = phoenixAPI.init(sbot) // create plugin api instance
 
-// api.on('post', cb) // emitted on each new toplevel post
-// :TODO: replace this, maybe with a source stream
+pull(api.events(), pull.drain(function (event))) // event emitting stream
+// emits { type: 'post', post: Object } for each new toplevel post
 
 api.getFeed({ gt:, gte:, lt:, lte:, limit:, reverse: }, cb) // get raw messages. gt/e, lt/e can be message objects
 

--- a/README.md
+++ b/README.md
@@ -25,10 +25,6 @@ api.getAdverts({ start:, end: }, cb) // get advert messages. start/end are offse
 api.getAdvertCount(cb) // get number of adverts
 api.getRandomAdverts(num, oldest, cb) // get `num` adverts from the `oldest` most recent messages
 
-api.postText(text, cb) // publish post
-api.postReply(text, parentKey, cb) // publish reply
-api.postAdvert(text, cb) // publish advert
-
 api.getMsg(key, cb) // get message data
 api.getReplies(key, cb) // get replies to a message
 api.getPostParent(key, cb) // get parent post to a reply (null if none)
@@ -44,6 +40,4 @@ api.getAllProfiles(cb) // gets all profiles in id->profile map
 api.getNamesById(cb) // gets map of id->names
 api.getName(id, cb) // gets name for the given id
 api.getIdsByName(cb) // gets map of names->id
-api.nameSelf(name, cb) // publish new name for self
-api.nameOther(target, name, cb) // publish new name for target
 ```

--- a/index.js
+++ b/index.js
@@ -160,32 +160,6 @@ exports.init = function (sbot) {
     cb(null, state.ids)
   }
 
-  // publishers
-
-  api.postText = function (text, cb) {
-    if (!text.trim()) return cb(new Error('Can not post an empty string to the feed'))
-    sbot.feed.add(extractMentions({type: 'post', text: text}), processor.whenIndexed(cb))
-  }
-  api.postReply = function (text, parent, cb) {
-    if (!text.trim()) return cb(new Error('Can not post an empty string to the feed'))
-    if (!parent) return cb(new Error('Must provide a parent message to the reply'))
-    sbot.feed.add(extractMentions({type: 'post', text: text, repliesTo: {msg: parent, rel: 'replies-to'}}), processor.whenIndexed(cb))
-  }
-  api.postAdvert = function (text, cb) {
-    if (!text.trim()) return cb(new Error('Can not post an empty string to the adverts'))
-    sbot.feed.add({type: 'advert', text: text}, processor.whenIndexed(cb))
-  }
-
-  api.nameSelf = function (name, cb) {
-    if (typeof name != 'string' || name.trim() == '') return cb(new Error('param 1 `name` string is required and must be non-empty'))
-    sbot.feed.add({type: 'name', name: name}, processor.whenIndexed(cb))
-  }
-  api.nameOther = function (target, name, cb) {
-    if (!target || typeof target != 'string') return cb(new Error('param 1 `target` feed string is required'))
-    if (typeof name != 'string' || name.trim() == '') return cb(new Error('param 2 `name` string is required and must be non-empty'))
-    sbot.feed.add({type: 'name', rel: 'names', feed: target, name: name}, processor.whenIndexed(cb))
-  }
-
   // helper to get an option off an opt function (avoids the `opt || {}` pattern)
   function o (opts, k, def) {
     return opts && opts[k] !== void 0 ? opts[k] : def
@@ -207,17 +181,6 @@ exports.init = function (sbot) {
         .forEach(function (key) { api.getMsg(key, done()) })
       done(cb)
     }
-  }
-
-  // helper to find mentions in .text in put them in link objects
-  function extractMentions (content) {
-    var match
-    var mentionRegex = /(\s|^)@([A-z0-9\/=\.\+]+)/g;
-    while ((match = mentionRegex.exec(content.text))) {
-      content.mentions = content.mentions || []
-      content.mentions.push({ feed: match[2], rel: 'mentions' })
-    }
-    return content
   }
 
   // helper to convert gt,gte,lt,lte params from messages into proper keys for the feeddb index

--- a/index.js
+++ b/index.js
@@ -28,8 +28,6 @@ exports.init = function (sbot) {
   var processor = require('./processor')(sbot, state)
   pull(sbot.ssb.createLogStream({ live: true }), pull.drain(processor))
 
-  // :TODO: replace the on('post') situation
-  // var api = new EventEmitter()
   // events stream
   var eventsStream = pushable()
   processor.events.on('post', function (post) {

--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ exports.init = function (sbot) {
   // getters
 
   api.getMyProfile = function (cb) {
-    return this.getProfile(state.myid, cb)
+    return api.getProfile(sbot.feed.id, cb)
   }
 
   api.getThreadMeta = function (key, cb) {

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
-var pull         = require('pull-stream')
-var ssbmsgs      = require('ssb-msgs')
-var multicb      = require('multicb')
-var EventEmitter = require('events').EventEmitter
+var pull     = require('pull-stream')
+var ssbmsgs  = require('ssb-msgs')
+var multicb  = require('multicb')
+var pushable = require('pull-pushable')
 
 exports.manifest    = require('./manifest')
 exports.permissions = require('./permissions')
@@ -30,9 +30,17 @@ exports.init = function (sbot) {
 
   // :TODO: replace the on('post') situation
   // var api = new EventEmitter()
-  // processor.events.on('post', api.emit.bind(api, 'post'))
+  // events stream
+  var eventsStream = pushable()
+  processor.events.on('post', function (post) {
+    eventsStream.push({ type: 'post', post: post })
+  })
 
   // getters
+
+  api.events = function () {
+    return eventsStream
+  }
 
   api.getMyProfile = function (cb) {
     return api.getProfile(sbot.feed.id, cb)

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ exports.permissions = require('./permissions')
 
 exports.init = function (sbot) {
 
+  var api = {}
   var state = {
     // indexes
     posts: [],
@@ -24,7 +25,7 @@ exports.init = function (sbot) {
   }
   state.postsByAuthor[sbot.feed.id] = state.myposts // alias myposts inside postsByAuthor
 
-  var processor = require('./processor')(state)
+  var processor = require('./processor')(sbot, state)
   pull(sbot.ssb.createLogStream({ live: true }), pull.drain(processor))
 
   // :TODO: replace the on('post') situation

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 var pull     = require('pull-stream')
 var ssbmsgs  = require('ssb-msgs')
 var multicb  = require('multicb')
+var memview  = require('level-memview')
 var pushable = require('pull-pushable')
 
 exports.manifest    = require('./manifest')
@@ -26,7 +27,7 @@ exports.init = function (sbot) {
   state.postsByAuthor[sbot.feed.id] = state.myposts // alias myposts inside postsByAuthor
 
   var processor = require('./processor')(sbot, state)
-  pull(sbot.ssb.createLogStream({ live: true }), pull.drain(processor))
+  var awaitSync = memview(sbot.ssb, processor, function () { return null })
 
   // events stream
   var eventsStream = pushable()
@@ -41,123 +42,147 @@ exports.init = function (sbot) {
   }
 
   api.getMyProfile = function (cb) {
-    return api.getProfile(sbot.feed.id, cb)
+    awaitSync(function () {
+      api.getProfile(sbot.feed.id, cb)
+    })
   }
 
   api.getThreadMeta = function (key, cb) {
-    cb(null, state.threads[key])
+    awaitSync(function () {
+      cb(null, state.threads[key])
+    })
   }
   api.getAllThreadMetas = function (cb) {
-    cb(null, state.threads)
+    awaitSync(function () {
+      cb(null, state.threads)
+    })
   }
 
   api.getMsg = function (key, cb) {
-    sbot.ssb.get(key, function (err, msg) {
-      if (err) cb(err)
-      else {
-        var obj = { key: key, value: msg }
-        if (state.threads[key]) {
-          for (var k in state.threads[key])
-            obj[k] = state.threads[key][k]
+    awaitSync(function () {
+      sbot.ssb.get(key, function (err, msg) {
+        if (err) cb(err)
+        else {
+          var obj = { key: key, value: msg }
+          if (state.threads[key]) {
+            for (var k in state.threads[key])
+              obj[k] = state.threads[key][k]
+          }
+          cb(null, obj)
         }
-        cb(null, obj)
-      }
+      })
     })
   }
   api.getReplies = function (key, cb) {
-    if (key in state.threads && state.threads[key].replies.length) {
-      var done = multicb({ pluck: 1 })
-      state.threads[key].replies.forEach(function (rkey) { api.getMsg(rkey, done()) })
-      return done(cb)
-    }
-    cb(null, [])
+    awaitSync(function () {
+      if (key in state.threads && state.threads[key].replies.length) {
+        var done = multicb({ pluck: 1 })
+        state.threads[key].replies.forEach(function (rkey) { api.getMsg(rkey, done()) })
+        return done(cb)
+      }
+      cb(null, [])
+    })
   }
   api.getPostParent = function (key, cb) {
-    if (key in state.threads && state.threads[key].parent)
-      api.getMsg(state.threads[key].parent, cb)
-    else
-      cb(null, null)
+    awaitSync(function () {
+      if (key in state.threads && state.threads[key].parent)
+        api.getMsg(state.threads[key].parent, cb)
+      else
+        cb(null, null)
+    })
   }
   api.getThread = function (key, cb) {
-    var done = multicb()
-    var thread = { key: key, value: null, replies: null, numThreadReplies: 0, parent: null }
-    get(thread, done())
+    awaitSync(function () {
+      var done = multicb()
+      var thread = { key: key, value: null, replies: null, numThreadReplies: 0, parent: null }
+      get(thread, done())
 
-    function get(t, cb) {
-      api.getMsg(t.key, function (err, msg) {
+      function get(t, cb) {
+        api.getMsg(t.key, function (err, msg) {
+          if (err) return cb(err)
+          t.value = msg.value
+          cb(null, t)
+        })
+        replies(t)
+      }
+
+      function replies(t) {
+        if (!state.threads[t.key])
+          return
+        t.parent = state.threads[t.key].parent
+        t.numThreadReplies = state.threads[t.key].numThreadReplies
+        t.replies = state.threads[t.key].replies.map(function (rkey) {
+          var rt = { key: rkey, value: null, replies: null, numThreadReplies: 0, parent: null }
+          get(rt, done())
+          return rt
+        })
+      }
+
+      done(function (err) {
         if (err) return cb(err)
-        t.value = msg.value
-        cb(null, t)
+        cb(null, thread)
       })
-      replies(t)
-    }
-
-    function replies(t) {
-      if (!state.threads[t.key])
-        return
-      t.parent = state.threads[t.key].parent
-      t.numThreadReplies = state.threads[t.key].numThreadReplies
-      t.replies = state.threads[t.key].replies.map(function (rkey) {
-        var rt = { key: rkey, value: null, replies: null, numThreadReplies: 0, parent: null }
-        get(rt, done())
-        return rt
-      })
-    }
-
-    done(function (err) {
-      if (err) return cb(err)
-      cb(null, thread)
     })
   }
 
   api.getFeed = function (opts, cb) {
-    opts = opts || {}
-    opts.keys = true
-    opts.limit = opts.limit || 30
+    awaitSync(function () {
+      opts = opts || {}
+      opts.keys = true
+      opts.limit = opts.limit || 30
 
-    // convert gt, gte, lt, lte so that you can do `getFeed({ gt: msg1, lt: msg2 })`
-    opts.gt  = msgToFeedDBKey(opts.gt)
-    opts.gte = msgToFeedDBKey(opts.gte)
-    opts.lt  = msgToFeedDBKey(opts.lt)
-    opts.lte = msgToFeedDBKey(opts.lte)
+      // convert gt, gte, lt, lte so that you can do `getFeed({ gt: msg1, lt: msg2 })`
+      opts.gt  = msgToFeedDBKey(opts.gt)
+      opts.gte = msgToFeedDBKey(opts.gte)
+      opts.lt  = msgToFeedDBKey(opts.lt)
+      opts.lte = msgToFeedDBKey(opts.lte)
 
-    pull(
-      sbot.ssb.createFeedStream(opts),
-      pull.collect(cb)
-    )
+      pull(
+        sbot.ssb.createFeedStream(opts),
+        pull.collect(cb)
+      )
+    })
   }
   api.getPosts = listGetter(state.posts)
-  api.getPostCount = function (cb) { cb(null, state.posts.length) }
+  api.getPostCount = function (cb) { 
+    awaitSync(function() { cb(null, state.posts.length) })
+  }
   api.getPostsBy = function (author, opts, cb) {
     listGetter(state.postsByAuthor[author] || [])(opts, cb)
   }
   api.getInbox = listGetter(state.inbox)
-  api.getInboxCount = function (cb) { cb(null, state.inbox.length) }
+  api.getInboxCount = function (cb) { 
+    awaitSync(function () { cb(null, state.inbox.length) })
+  }
   api.getAdverts = listGetter(state.adverts)
-  api.getAdvertCount = function (cb) { cb(null, state.adverts.length) }
+  api.getAdvertCount = function (cb) { 
+    awaitSync(function () { cb(null, state.adverts.length) })
+  }
   api.getRandomAdverts = function (num, oldest, cb) {
-    var done = multicb({ pluck: 1 })
-    for (var i = 0; i < num && i < state.adverts.length; i++) {
-      var index = (Math.random()*Math.min(state.adverts.length, oldest))|0
-      api.getMsg(state.adverts[index], done())
-    }
-    return done(cb)
+    awaitSync(function () {
+      var done = multicb({ pluck: 1 })
+      for (var i = 0; i < num && i < state.adverts.length; i++) {
+        var index = (Math.random()*Math.min(state.adverts.length, oldest))|0
+        api.getMsg(state.adverts[index], done())
+      }
+      done(cb)
+    })
   }
 
   api.getProfile = function (id, cb) {
-    cb(null, state.profiles[id])
+    awaitSync(function() { cb(null, state.profiles[id]) })
   }
   api.getAllProfiles = function (cb) {
-    cb(null, state.profiles)
+    awaitSync(function() { cb(null, state.profiles) })
   }
   api.getNamesById = function (cb) {
-    cb(null, state.names)
+    awaitSync(function() { cb(null, state.names) })
   }
   api.getName = function (id, cb) {
-    cb(null, state.names[id])
+    awaitSync(function() { cb(null, state.names[id]) })
   }
   api.getIdsByName = function (cb) {
-    cb(null, state.ids)
+    awaitSync(function() { cb(null, state.ids) })
   }
 
   // helper to get an option off an opt function (avoids the `opt || {}` pattern)
@@ -168,18 +193,20 @@ exports.init = function (sbot) {
   // helper to get messages from an index
   function listGetter (index) {
     return function (opts, cb) {
-      if (typeof opts == 'function') {
-        cb = opts
-        opts = null
-      }
-      var start = o(opts, 'start', 0)
-      var end   = o(opts, 'end', start + 30)
+      awaitSync(function() {
+        if (typeof opts == 'function') {
+          cb = opts
+          opts = null
+        }
+        var start = o(opts, 'start', 0)
+        var end   = o(opts, 'end', start + 30)
 
-      var done = multicb({ pluck: 1 })
-      index
-        .slice(start, end)
-        .forEach(function (key) { api.getMsg(key, done()) })
-      done(cb)
+        var done = multicb({ pluck: 1 })
+        index
+          .slice(start, end)
+          .forEach(function (key) { api.getMsg(key, done()) })
+        done(cb)
+      })
     }
   }
 

--- a/manifest.js
+++ b/manifest.js
@@ -1,4 +1,6 @@
 module.exports = {
+  events: 'source',
+
   getFeed: 'async',
 
   getPosts: 'async',

--- a/manifest.js
+++ b/manifest.js
@@ -14,10 +14,6 @@ module.exports = {
   getAdvertCount: 'async',
   getRandomAdverts: 'async',
 
-  postText: 'async',
-  postReply: 'async',
-  postAdvert: 'async',
-
   getMsg: 'async',
   getReplies: 'async',
   getPostParent: 'async',
@@ -31,7 +27,5 @@ module.exports = {
 
   getNamesById: 'async',
   getName: 'async',
-  getIdsByName: 'async',
-  nameSelf: 'async',
-  nameOther: 'async'
+  getIdsByName: 'async'
 }

--- a/manifest.js
+++ b/manifest.js
@@ -2,6 +2,7 @@ module.exports = {
   getFeed: 'async',
 
   getPosts: 'async',
+  getPostsBy: 'async',
   getPostCount: 'async',
 
   getInbox: 'async',

--- a/manifest.js
+++ b/manifest.js
@@ -2,7 +2,7 @@ module.exports = {
   getFeed: 'async',
 
   getPosts: 'async',
-  getPostCount: 'asyc',
+  getPostCount: 'async',
 
   getInbox: 'async',
   getInboxCount: 'async',

--- a/manifest.js
+++ b/manifest.js
@@ -9,7 +9,7 @@ module.exports = {
 
   getAdverts: 'async',
   getAdvertCount: 'async',
-  getRandomAdverts: 'async'
+  getRandomAdverts: 'async',
 
   postText: 'async',
   postReply: 'async',
@@ -26,7 +26,7 @@ module.exports = {
   getProfile: 'async',
   getAllProfiles: 'async',
 
-  getNamesById: 'async'
+  getNamesById: 'async',
   getName: 'async',
   getIdsByName: 'async',
   nameSelf: 'async',

--- a/manifest.js
+++ b/manifest.js
@@ -1,0 +1,34 @@
+module.exports = {
+  getFeed: 'async',
+
+  getPosts: 'async',
+  getPostCount: 'asyc',
+
+  getInbox: 'async',
+  getInboxCount: 'async',
+
+  getAdverts: 'async',
+  getAdvertCount: 'async',
+  getRandomAdverts: 'async'
+
+  postText: 'async',
+  postReply: 'async',
+  postAdvert: 'async',
+
+  getMsg: 'async',
+  getReplies: 'async',
+  getPostParent: 'async',
+  getThread: 'async',
+  getThreadMeta: 'async',
+  getAllThreadMetas: 'async',
+
+  getMyProfile: 'async',
+  getProfile: 'async',
+  getAllProfiles: 'async',
+
+  getNamesById: 'async'
+  getName: 'async',
+  getIdsByName: 'async',
+  nameSelf: 'async',
+  nameOther: 'async'
+}

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "url": "git://github.com/ssbc/phoenix-api.git"
   },
   "dependencies": {
+    "level-memview": "~0.0.0",
     "multicb": "~1.1.0",
     "pull-stream": "~2.24.1",
     "pull-pushable": "~1.1.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "phoenix-api",
   "version": "2.1.1",
-  "description": "methods for reading and writing to the log from the phoenix gui",
+  "description": "scuttlebot rpc methods for accessing the log from the phoenix gui",
   "main": "index.js",
   "scripts": {
     "test": "set -e; for t in test/*.js; do node $t; done"

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "multicb": "~1.1.0",
     "pull-stream": "~2.24.1",
+    "pull-pushable": "~1.1.3",
     "ssb-msgs": "~1.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "multicb": "~1.1.0",
     "pull-stream": "~2.24.1",
     "pull-pushable": "~1.1.3",
-    "ssb-msgs": "~1.0.0"
+    "ssb-msgs": "~2.0.0"
   },
   "devDependencies": {
     "osenv": "~0.1.0",
@@ -22,6 +22,7 @@
     "scuttlebot": "~1.2.2",
     "secure-scuttlebutt": "~8.0.0",
     "ssb-keys": "~0.4.1",
+    "ssb-msg-schemas": "~1.0.0",
     "tape": "~3.0.0"
   },
   "author": "Paul Frazee <pfrazee@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "osenv": "~0.1.0",
     "rimraf": "~2.2.8",
-    "scuttlebot": "~1.2.2",
+    "scuttlebot": "~2.0.0",
     "secure-scuttlebutt": "~8.0.0",
     "ssb-keys": "~0.4.1",
     "ssb-msg-schemas": "~1.0.0",

--- a/permissions.js
+++ b/permissions.js
@@ -1,0 +1,1 @@
+module.exports = { anonymous: { allow: [] } } // allow nothing unless master

--- a/processor.js
+++ b/processor.js
@@ -1,7 +1,7 @@
 var ssbmsgs = require('ssb-msgs')
 var EventEmitter = require('events').EventEmitter
 
-module.exports = function(state) {
+module.exports = function(sbot, state) {
 
   // :NOTE: messages may arrive to the indexer out of order since theyre fetched in type-divided streams
   //        that's currently ok because the indexer doesnt have causality deps between types
@@ -33,7 +33,7 @@ module.exports = function(state) {
           profile.given[author] = profile.given[author] || {}
           profile.given[author].name = name
 
-          if (author === state.myid) {
+          if (author === sbot.feed.id) {
             // author is me, use name
             state.names[link.feed]  = name
             state.ids[name] = link.feed
@@ -44,12 +44,12 @@ module.exports = function(state) {
         var profile = getProfile(author)
         profile.self.name = name
 
-        if (author === state.myid) {
+        if (author === sbot.feed.id) {
           // author is me, use name
           state.names[author] = name
           state.ids[name] = author
         }
-        else if (!state.names[author] || !profile.given[state.myid] || !profile.given[state.myid].name) {
+        else if (!state.names[author] || !profile.given[sbot.feed.id] || !profile.given[sbot.feed.id].name) {
           // no name assigned by me, use their claimed name
           state.names[author] = '"' + name + '"'
           state.ids['"' + name + '"'] = author
@@ -85,7 +85,7 @@ module.exports = function(state) {
             isinboxed = true
           }
         }
-        else if (link.rel == 'mentions' && link.feed === state.myid && !isinboxed) {
+        else if (link.rel == 'mentions' && link.feed === sbot.feed.id && !isinboxed) {
           state.inbox.unshift(msg.key)
           isinboxed = true
         }

--- a/processor.js
+++ b/processor.js
@@ -3,10 +3,6 @@ var EventEmitter = require('events').EventEmitter
 
 module.exports = function(sbot, state) {
 
-  // :NOTE: messages may arrive to the indexer out of order since theyre fetched in type-divided streams
-  //        that's currently ok because the indexer doesnt have causality deps between types
-  //        but be wary of that as the indexer develops!
-
   var events = new EventEmitter()
   var cbsAwaitingProcessing = {} // map of key -> cb
   var processors = {

--- a/processor.js
+++ b/processor.js
@@ -4,7 +4,6 @@ var EventEmitter = require('events').EventEmitter
 module.exports = function(sbot, state) {
 
   var events = new EventEmitter()
-  var cbsAwaitingProcessing = {} // map of key -> cb
   var processors = {
     init: function (msg) {
       var profile = getProfile(msg.value.author)
@@ -139,19 +138,8 @@ module.exports = function(sbot, state) {
         console.warn('Failed to process message', e, msg)
       }
     }
-
-    var cb = cbsAwaitingProcessing[msg.key]
-    if (cb) {
-      delete cbsAwaitingProcessing[msg.key]
-      cb()
-    }
   }
   fn.events = events
-  fn.whenIndexed = function (cb) {
-    return function (err, msg) {
-      cbsAwaitingProcessing[msg.key] = cb.bind(null, err, msg)
-    }
-  }
 
   return fn
 }

--- a/test/api.js
+++ b/test/api.js
@@ -43,9 +43,9 @@ tape('posts, replies, and inbox', function (t) {
       t.equal(msg2.value.content.text, 'second')
       t.equal(msg2.value.content.repliesTo.msg, msg1.key)
 
-      sbot.phoenix.getThreadMeta(msg1.key, function (err, tmeta) {
+      sbot.phoenix.getMsg(msg1.key, function (err, msg1full) {
         if (err) throw err
-        t.equal(tmeta.replies.length, 1)
+        t.equal(msg1full.replies.length, 1)
 
         sbot.phoenix.getPosts(function (err, msgs) {
           if (err) throw err
@@ -116,6 +116,7 @@ tape('threads', function (t) {
           if (err) throw err
           t.equal(thread.value.content.text, 'top')
           t.equal(thread.replies.length, 2)
+          t.equal(thread.numThreadReplies, 5)
           t.equal(thread.replies[0].value.content.text, 'reply 2')
           t.equal(thread.replies[1].value.content.text, 'reply 1')
           t.equal(thread.replies[0].replies.length, 1)
@@ -124,11 +125,7 @@ tape('threads', function (t) {
           t.equal(thread.replies[1].replies[0].value.content.text, 'reply 1 reply 2')
           t.equal(thread.replies[1].replies[1].value.content.text, 'reply 1 reply 1')
 
-          sbot.phoenix.getThreadMeta(msg1.key, function (err, tmeta) {
-            if (err) throw err
-            t.equal(tmeta.numThreadReplies, 5)
-            t.end()
-          })
+          t.end()
         })
       })
     })

--- a/test/api.js
+++ b/test/api.js
@@ -1,6 +1,7 @@
 var multicb = require('multicb')
 var tape    = require('tape')
 var ssbKeys = require('ssb-keys')
+var pull    = require('pull-stream')
 
 tape('feed', function (t) {
   var sbot = require('./util').newserver()
@@ -33,6 +34,12 @@ tape('feed', function (t) {
 
 tape('posts, replies, and inbox', function (t) {
   var sbot = require('./util').newserver()
+
+  var numNewPosts = 0
+  pull(sbot.phoenix.events(), pull.drain(function (e) {
+    if (e.type == 'post')
+      numNewPosts++
+  }))
 
   sbot.phoenix.postText('first', function (err, msg1) {
     if (err) throw err
@@ -77,6 +84,7 @@ tape('posts, replies, and inbox', function (t) {
                       t.equal(msgs.length, 2)
                       t.equal(msgs[0].value.content.text, 'hello @'+sbot.feed.id)
                       t.equal(msgs[1].value.content.text, 'second')
+                      t.equal(numNewPosts, 2)
                       t.end()
                     })
                   })

--- a/test/api.js
+++ b/test/api.js
@@ -3,79 +3,79 @@ var tape    = require('tape')
 var ssbKeys = require('ssb-keys')
 
 tape('feed', function (t) {
-  require('./util').newapi(function (err, api, ssb, feed) {
+  var sbot = require('./util').newserver()
+
+  var done = multicb()
+  sbot.phoenix.postText('1', done())
+  sbot.phoenix.postText('2', done())
+  sbot.phoenix.postText('3', done())
+  sbot.phoenix.postText('4', done())
+  sbot.phoenix.postText('5', done())
+  sbot.phoenix.postText('6', done())
+  done(function (err) {
     if (err) throw err
 
-    var done = multicb()
-    api.postText('1', done())
-    api.postText('2', done())
-    api.postText('3', done())
-    api.postText('4', done())
-    api.postText('5', done())
-    api.postText('6', done())
-    done(function (err) {
+    sbot.phoenix.getFeed({ limit: 2, reverse: true }, function (err, msgs) {
       if (err) throw err
+      t.equal(msgs[0].value.content.text, '6')
+      t.equal(msgs[1].value.content.text, '5')
 
-      api.getFeed({ limit: 2, reverse: true }, function (err, msgs) {
+      sbot.phoenix.getFeed({ limit: 2, reverse: true, lt: msgs[1] }, function (err, msgs) {
         if (err) throw err
-        t.equal(msgs[0].value.content.text, '6')
-        t.equal(msgs[1].value.content.text, '5')
+        t.equal(msgs[0].value.content.text, '4')
+        t.equal(msgs[1].value.content.text, '3')
 
-        api.getFeed({ limit: 2, reverse: true, lt: msgs[1] }, function (err, msgs) {
-          if (err) throw err
-          t.equal(msgs[0].value.content.text, '4')
-          t.equal(msgs[1].value.content.text, '3')
-
-          t.end()
-        })
+        t.end()
       })
     })
   })
 })
 
 tape('posts, replies, and inbox', function (t) {
-  require('./util').newapi(function (err, api, ssb, feed) {
+  var sbot = require('./util').newserver()
+
+  sbot.phoenix.postText('first', function (err, msg1) {
     if (err) throw err
+    t.equal(msg1.value.content.text, 'first')
 
-    api.postText('first', function (err, msg1) {
+    sbot.phoenix.postReply('second', msg1.key, function (err, msg2) {
       if (err) throw err
-      t.equal(msg1.value.content.text, 'first')
+      t.equal(msg2.value.content.text, 'second')
+      t.equal(msg2.value.content.repliesTo.msg, msg1.key)
 
-      api.postReply('second', msg1.key, function (err, msg2) {
+      sbot.phoenix.getThreadMeta(msg1.key, function (err, tmeta) {
         if (err) throw err
-        t.equal(msg2.value.content.text, 'second')
-        t.equal(msg2.value.content.repliesTo.msg, msg1.key)
-        t.equal(api.getReplyCount(msg1.key), 1)
+        t.equal(tmeta.replies.length, 1)
 
-        api.getPosts(function (err, msgs) {
+        sbot.phoenix.getPosts(function (err, msgs) {
           if (err) throw err
           t.equal(msgs.length, 1)
           t.equal(msgs[0].value.content.text, 'first')
 
-          api.getMsg(msg1.key, function (err, msg1b) {
+          sbot.phoenix.getMsg(msg1.key, function (err, msg1b) {
             if (err) throw err
             t.equal(msg1b.value.content.text, 'first')
 
-            api.getReplies(msg1.key, function (err, replies) {
+            sbot.phoenix.getReplies(msg1.key, function (err, replies) {
               if (err) throw err
               t.equal(replies.length, 1)
               t.equal(replies[0].value.content.text, 'second')
 
-              api.getPostParent(replies[0].key, function (err, parent) {
+              sbot.phoenix.getPostParent(replies[0].key, function (err, parent) {
                 if (err) throw err
                 t.equal(parent.key, msg1.key)
 
-                api.getPostParent(msg1.key, function (err, parent2) {
+                sbot.phoenix.getPostParent(msg1.key, function (err, parent2) {
                   if (err) throw err
                   t.assert(!parent2)
 
-                  api.postText('hello @'+feed.id, function (err, msg3) {
+                  sbot.phoenix.postText('hello @'+sbot.feed.id, function (err, msg3) {
                     if (err) throw err
 
-                    api.getInbox(function (err, msgs) {
+                    sbot.phoenix.getInbox(function (err, msgs) {
                       if (err) throw err
                       t.equal(msgs.length, 2)
-                      t.equal(msgs[0].value.content.text, 'hello @'+feed.id)
+                      t.equal(msgs[0].value.content.text, 'hello @'+sbot.feed.id)
                       t.equal(msgs[1].value.content.text, 'second')
                       t.end()
                     })
@@ -90,43 +90,43 @@ tape('posts, replies, and inbox', function (t) {
   })
 })
 
-
 tape('threads', function (t) {
-  require('./util').newapi(function (err, api, ssb, feed) {
-    if (err) throw err
+  var sbot = require('./util').newserver()
 
-    api.postText('top', function (err, msg1) {
+  sbot.phoenix.postText('top', function (err, msg1) {
+    if (err) throw err
+    t.equal(msg1.value.content.text, 'top')
+
+    var done = multicb({ pluck: 1 })
+    sbot.phoenix.postReply('reply 1', msg1.key, done())
+    sbot.phoenix.postReply('reply 2', msg1.key, done())
+    done(function (err, replies) {
       if (err) throw err
-      t.equal(msg1.value.content.text, 'top')
+      t.equal(replies.length, 2)
 
       var done = multicb({ pluck: 1 })
-      api.postReply('reply 1', msg1.key, done())
-      api.postReply('reply 2', msg1.key, done())
-      done(function (err, replies) {
+      sbot.phoenix.postReply('reply 1 reply 1', replies[0].key, done())
+      sbot.phoenix.postReply('reply 1 reply 2', replies[0].key, done())
+      sbot.phoenix.postReply('reply 2 reply 1', replies[1].key, done())
+      done(function (err, replies2) {
         if (err) throw err
-        t.equal(replies.length, 2)
+        t.equal(replies2.length, 3)
 
-        var done = multicb({ pluck: 1 })
-        api.postReply('reply 1 reply 1', replies[0].key, done())
-        api.postReply('reply 1 reply 2', replies[0].key, done())
-        api.postReply('reply 2 reply 1', replies[1].key, done())
-        done(function (err, replies2) {
+        sbot.phoenix.getThread(msg1.key, function (err, thread) {
           if (err) throw err
-          t.equal(replies2.length, 3)
+          t.equal(thread.value.content.text, 'top')
+          t.equal(thread.replies.length, 2)
+          t.equal(thread.replies[0].value.content.text, 'reply 2')
+          t.equal(thread.replies[1].value.content.text, 'reply 1')
+          t.equal(thread.replies[0].replies.length, 1)
+          t.equal(thread.replies[0].replies[0].value.content.text, 'reply 2 reply 1')
+          t.equal(thread.replies[1].replies.length, 2)
+          t.equal(thread.replies[1].replies[0].value.content.text, 'reply 1 reply 2')
+          t.equal(thread.replies[1].replies[1].value.content.text, 'reply 1 reply 1')
 
-          api.getThread(msg1.key, function (err, thread) {
+          sbot.phoenix.getThreadMeta(msg1.key, function (err, tmeta) {
             if (err) throw err
-            t.equal(thread.value.content.text, 'top')
-            t.equal(thread.replies.length, 2)
-            t.equal(thread.replies[0].value.content.text, 'reply 2')
-            t.equal(thread.replies[1].value.content.text, 'reply 1')
-            t.equal(thread.replies[0].replies.length, 1)
-            t.equal(thread.replies[0].replies[0].value.content.text, 'reply 2 reply 1')
-            t.equal(thread.replies[1].replies.length, 2)
-            t.equal(thread.replies[1].replies[0].value.content.text, 'reply 1 reply 2')
-            t.equal(thread.replies[1].replies[1].value.content.text, 'reply 1 reply 1')
-            t.equal(api.getThreadReplyCount(msg1.key), 5)
-
+            t.equal(tmeta.numThreadReplies, 5)
             t.end()
           })
         })
@@ -136,143 +136,102 @@ tape('threads', function (t) {
 })
 
 tape('posts by author', function (t) {
-  require('./util').newapi(function (err, api, ssb, feed) {
+  var sbot = require('./util').newserver()
+
+  var alice = sbot.ssb.createFeed(ssbKeys.generate())
+  var bob   = sbot.ssb.createFeed(ssbKeys.generate())
+
+  var done = multicb()
+  sbot.phoenix.postText('post by me 1', done())
+  sbot.phoenix.postText('post by me 2', done())
+  alice.add({ type: 'post', text: 'post by alice' }, done())
+  bob  .add({ type: 'post', text: 'post by bob' }, done())
+  done(function (err) {
     if (err) throw err
+    // kludge: wait for the alice.add and bob.add to be indexed
+    setTimeout(function () {
+      var done = multicb({ pluck: 1 })
+      sbot.phoenix.getPostsBy(sbot.feed.id, done())
+      sbot.phoenix.getPostsBy(alice.id, done())
+      sbot.phoenix.getPostsBy(bob.id, done())
 
-    var alice = ssb.createFeed(ssbKeys.generate())
-    var bob   = ssb.createFeed(ssbKeys.generate())
+      done(function (err, posts) {
+        if (err) throw err
+        t.equal(posts[0].length, 2)
+        t.equal(posts[0][0].value.content.text, 'post by me 2')
+        t.equal(posts[0][1].value.content.text, 'post by me 1')
+        t.equal(posts[1][0].value.content.text, 'post by alice')
+        t.equal(posts[2][0].value.content.text, 'post by bob')
 
-    var done = multicb()
-    api.postText('post by me 1', done())
-    api.postText('post by me 2', done())
-    alice.add({ type: 'post', text: 'post by alice' }, done())
-    bob  .add({ type: 'post', text: 'post by bob' }, done())
-    done(function (err) {
-      if (err) throw err
-      // kludge: wait for the alice.add and bob.add to be indexed
-      setTimeout(function () {
-        var done = multicb({ pluck: 1 })
-        api.getPostsBy(feed.id, done())
-        api.getPostsBy(alice.id, done())
-        api.getPostsBy(bob.id, done())
-
-        done(function (err, posts) {
-          if (err) throw err
-          t.equal(posts[0].length, 2)
-          t.equal(posts[0][0].value.content.text, 'post by me 2')
-          t.equal(posts[0][1].value.content.text, 'post by me 1')
-          t.equal(posts[1][0].value.content.text, 'post by alice')
-          t.equal(posts[2][0].value.content.text, 'post by bob')
-
-          t.end()
-        })
-      }, 100)
-    })
+        t.end()
+      })
+    }, 100)
   })
 })
 
 tape('adverts', function (t) {
-  require('./util').newapi(function (err, api, ssb, feed) {
+  var sbot = require('./util').newserver()
+
+  var done = multicb()
+  sbot.phoenix.postAdvert('1', done())
+  sbot.phoenix.postAdvert('2', done())
+  sbot.phoenix.postAdvert('3', done())
+  sbot.phoenix.postAdvert('4', done())
+  sbot.phoenix.postAdvert('5', done())
+  sbot.phoenix.postAdvert('6', done())
+  done(function (err) {
     if (err) throw err
 
-    var done = multicb()
-    api.postAdvert('1', done())
-    api.postAdvert('2', done())
-    api.postAdvert('3', done())
-    api.postAdvert('4', done())
-    api.postAdvert('5', done())
-    api.postAdvert('6', done())
-    done(function (err) {
+    sbot.phoenix.getAdverts(function (err, ads) {
       if (err) throw err
+      t.equal(ads.length, 6)
+      t.equal(ads[0].value.content.text, '6')
+      t.equal(ads[1].value.content.text, '5')
+      t.equal(ads[2].value.content.text, '4')
+      t.equal(ads[3].value.content.text, '3')
+      t.equal(ads[4].value.content.text, '2')
+      t.equal(ads[5].value.content.text, '1')
 
-      api.getAdverts(function (err, ads) {
+      sbot.phoenix.getRandomAdverts(2, 5, function (err, ads) {
         if (err) throw err
-        t.equal(ads.length, 6)
-        t.equal(ads[0].value.content.text, '6')
-        t.equal(ads[1].value.content.text, '5')
-        t.equal(ads[2].value.content.text, '4')
-        t.equal(ads[3].value.content.text, '3')
-        t.equal(ads[4].value.content.text, '2')
-        t.equal(ads[5].value.content.text, '1')
-
-        api.getRandomAdverts(2, 5, function (err, ads) {
-          if (err) throw err
-          t.equal(ads.length, 2)
-          t.ok(ads[0].value.content.text != '1') // there's only a statistical chance this can fail
-          t.ok(ads[1].value.content.text != '1') // if it fails, the use of the random function is wrong
-          t.end()
-        })
+        t.equal(ads.length, 2)
+        t.ok(ads[0].value.content.text != '1') // there's only a statistical chance this can fail
+        t.ok(ads[1].value.content.text != '1') // if it fails, the use of the random function is wrong
+        t.end()
       })
     })
   })
 })
 
 tape('names', function (t) {
-  require('./util').newapi(function (err, api, ssb, feed) {
+  var sbot = require('./util').newserver()
+
+  var alice = sbot.ssb.createFeed(ssbKeys.generate())
+  var bob   = sbot.ssb.createFeed(ssbKeys.generate())
+
+  var done = multicb()
+  sbot.phoenix.nameSelf('zed', done())
+  sbot.phoenix.nameOther(bob.id, 'robert', done())
+  alice.add({ type: 'name', name: 'alice' }, done())
+  bob  .add({ type: 'name', name: 'bob' }, done())
+  done(function (err) {
     if (err) throw err
+    // kludge: wait for the alice.add and bob.add to be indexed
+    setTimeout(function () {
+      sbot.phoenix.getNamesById(function (err, names) {
+        if (err) throw err
+        t.equal(names[sbot.feed.id], 'zed')
+        t.equal(names[alice.id],     '"alice"')
+        t.equal(names[bob.id],       'robert')
 
-    var alice = ssb.createFeed(ssbKeys.generate())
-    var bob   = ssb.createFeed(ssbKeys.generate())
-
-    var done = multicb()
-    api.nameSelf('zed', done())
-    api.nameOther(bob.id, 'robert', done())
-    alice.add({ type: 'name', name: 'alice' }, done())
-    bob  .add({ type: 'name', name: 'bob' }, done())
-    done(function (err) {
-      if (err) throw err
-      // kludge: wait for the alice.add and bob.add to be indexed
-      setTimeout(function () {
-        t.equal(api.getNameById(feed.id),   'zed')
-        t.equal(api.getNameById(alice.id),  '"alice"')
-        t.equal(api.getNameById(bob.id),    'robert')
-        t.equal(api.getIdByName('zed'),     feed.id)
-        t.equal(api.getIdByName('"alice"'), alice.id)
-        t.equal(api.getIdByName('robert'),  bob.id)
-        t.end()
-      }, 100)
-    })
-  })
-})
-
-tape('graph', function (t) {
-  require('./util').newapi(function (err, api, ssb, feed) {
-    if (err) throw err
-
-    var alice = ssb.createFeed(ssbKeys.generate())
-    var bob   = ssb.createFeed(ssbKeys.generate())
-
-    var done = multicb()
-    api.addEdge('follow', alice.id, done())
-    api.addEdge('follow', bob.id, done())
-    api.delEdge('follow', bob.id, done())
-    api.addEdge('trust', alice.id, done())
-    api.addEdge('flag', bob.id, done())
-    done(function (err) {
-      if (err) throw err
-      
-      // kludge: we have no way of knowing when the friends plugin has done its indexing, so we have to wait 100ms
-      setTimeout(function() {
-        var done = multicb({ pluck: 1 })
-        api.getGraph('follow', done())
-        api.getGraph('trust', done())
-        api.getGraph('flag', done())
-        done(function (err, graphs) {
+        sbot.phoenix.getIdsByName(function (err, ids) {
           if (err) throw err
-          var followGraph = graphs[0]
-          var trustGraph = graphs[1]
-          var flagGraph = graphs[2]
-
-          t.equal(followGraph[feed.id][alice.id], true)
-          t.equal(followGraph[feed.id][bob.id],   undefined)
-          t.equal(trustGraph [feed.id][alice.id], true)
-          t.equal(trustGraph [feed.id][bob.id],   undefined)
-          t.equal(flagGraph  [feed.id][alice.id], undefined)
-          t.equal(flagGraph  [feed.id][bob.id],   true)
-
+          t.equal(ids['zed'],     sbot.feed.id)
+          t.equal(ids['"alice"'], alice.id)
+          t.equal(ids['robert'],  bob.id)
           t.end()
         })
-      }, 100)
-    })
+      })
+    }, 100)
   })
 })

--- a/test/util.js
+++ b/test/util.js
@@ -1,22 +1,17 @@
 var path = require('path')
 var rimraf = require('rimraf')
 var osenv = require('osenv')
-var createApi = require('../')
+var phoenixApi = require('../')
+
+phoenixApi.name = 'phoenix'
+phoenixApi.version = '0.0.0'
 
 var n = 0
-exports.newapi = function (cb) {
+exports.newserver = function () {
   var dir = path.join(osenv.tmpdir(), 'phoenix-api-test'+(++n))
   rimraf.sync(dir)
 
-  var sbot = require('scuttlebot')({ path: dir }).use(require('scuttlebot/plugins/friends'))
-  var ssbapi = require('scuttlebot/lib/api')(sbot)
-  ssbapi.friends = {
-    all: function (type, cb) {
-      cb(null, sbot.friends.all(type))
-    }
-  }
-  var api = createApi(ssbapi)
-  api.startIndexing(function (err) {
-    cb(err, api, sbot.ssb, sbot.feed)
-  })
+  return require('scuttlebot')({ path: dir })
+    .use(require('scuttlebot/plugins/friends'))
+    .use(phoenixApi)
 }


### PR DESCRIPTION
this PR moves the phoenix-api methods into the serverside of phoenix's sbot plugin, which makes it easier to access the sbot leveldb instance (#2) and lets us process all messages as they come in (rather than as a set of `messagesByType` streams, which would give us ordering issues)
