### PR TITLE
Use names by trusted friends

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,9 @@ exports.init = function (sbot) {
 
     // views
     profiles: {},
+    trustedProfiles: {},
     names: {}, // ids -> names
+    nameTrustRanks: {}, // ids -> trust-ranks
     ids: {}, // names -> ids
     threads: {} // maps: post key -> { replies: [{ts:,key:}], parent:, numThreadReplies: }
   }
@@ -184,13 +186,7 @@ exports.init = function (sbot) {
     awaitSync(function () { cb(null, state.names) })
   }
   api.getNameTrustRanks = function (cb) {
-    awaitSync(function () {
-      var ranks = {}
-      for (var id in state.names)
-        ranks[id] = (state.profiles[id].given[sbot.feed.id] && state.profiles[id].given[sbot.feed.id].name) ? 1 : 0
-      ranks[sbot.feed.id] = 1
-      cb(null, ranks)
-    })
+    awaitSync(function () { cb(null, state.nameTrustRanks) })
   }
   api.getName = function (id, cb) {
     awaitSync(function () { cb(null, state.names[id]) })

--- a/processor.js
+++ b/processor.js
@@ -1,6 +1,7 @@
 var ssbmsgs = require('ssb-msgs')
 var EventEmitter = require('events').EventEmitter
 
+var trustLinkOpts = { tofeed: true, rel: 'trusts' }
 module.exports = function(sbot, state) {
 
   var events = new EventEmitter()
@@ -50,6 +51,20 @@ module.exports = function(sbot, state) {
           state.ids[name] = author
         }
       }
+    },
+
+    trust: function (msg) {
+      var content = msg.value.content
+      var author = msg.value.author
+
+      // only process self-published trust edges for now
+      if (author !== sbot.feed.id)
+        return
+
+      ssbmsgs.indexLinks(content, trustLinkOpts, function (link) {
+        var profile = getProfile(link.feed)
+        profile.trust = link.value || 0
+      })
     },
 
     post: function (msg) {
@@ -122,6 +137,7 @@ module.exports = function(sbot, state) {
         id: pid,
         self: { name: null },
         given: {},
+        trust: 0,
         createdAt: null
       }
     }

--- a/test/api.js
+++ b/test/api.js
@@ -246,6 +246,8 @@ tape('trust & names', function (t) {
   schemas.addOwnName(sbot.feed, 'zed', done())
   schemas.addOwnName(alice, 'alice', done())
   schemas.addOwnName(bob, 'bob', done())
+  schemas.addOtherName(bob, alice.id, 'alicia', done())
+  schemas.addOtherName(alice, bob.id, 'robert', done())
   schemas.addTrust(sbot.feed, alice.id, 1, done())
   done(function (err) {
     if (err) throw err
@@ -256,7 +258,27 @@ tape('trust & names', function (t) {
       if (err) throw err
       t.equal(profiles[0].trust, 1)
       t.equal(profiles[1].trust, 0)
-      t.end()
+
+      sbot.phoenix.getNamesById(function (err, names) {
+        if (err) throw err
+        t.equal(names[alice.id], 'alice')
+        t.equal(names[bob.id],   'robert')
+
+        var done = multicb()
+        schemas.addTrust(sbot.feed, alice.id, 0, done())
+        schemas.addTrust(sbot.feed, bob.id, 1, done())
+        done(function (err) {
+          if (err) throw err
+
+          sbot.phoenix.getNamesById(function (err, names) {
+            if (err) throw err
+            t.equal(names[alice.id], 'alicia')
+            t.equal(names[bob.id],   'bob')
+
+            t.end()
+          })
+        })
+      })
     })
   })
 })

--- a/test/api.js
+++ b/test/api.js
@@ -154,24 +154,21 @@ tape('posts by author', function (t) {
   bob  .add({ type: 'post', text: 'post by bob' }, done())
   done(function (err) {
     if (err) throw err
-    // kludge: wait for the alice.add and bob.add to be indexed
-    setTimeout(function () {
-      var done = multicb({ pluck: 1 })
-      sbot.phoenix.getPostsBy(sbot.feed.id, done())
-      sbot.phoenix.getPostsBy(alice.id, done())
-      sbot.phoenix.getPostsBy(bob.id, done())
+    var done = multicb({ pluck: 1 })
+    sbot.phoenix.getPostsBy(sbot.feed.id, done())
+    sbot.phoenix.getPostsBy(alice.id, done())
+    sbot.phoenix.getPostsBy(bob.id, done())
 
-      done(function (err, posts) {
-        if (err) throw err
-        t.equal(posts[0].length, 2)
-        t.equal(posts[0][0].value.content.text, 'post by me 2')
-        t.equal(posts[0][1].value.content.text, 'post by me 1')
-        t.equal(posts[1][0].value.content.text, 'post by alice')
-        t.equal(posts[2][0].value.content.text, 'post by bob')
+    done(function (err, posts) {
+      if (err) throw err
+      t.equal(posts[0].length, 2)
+      t.equal(posts[0][0].value.content.text, 'post by me 2')
+      t.equal(posts[0][1].value.content.text, 'post by me 1')
+      t.equal(posts[1][0].value.content.text, 'post by alice')
+      t.equal(posts[2][0].value.content.text, 'post by bob')
 
-        t.end()
-      })
-    }, 100)
+      t.end()
+    })
   })
 })
 
@@ -222,22 +219,44 @@ tape('names', function (t) {
   schemas.addOwnName(bob, 'bob', done())
   done(function (err) {
     if (err) throw err
-    // kludge: wait for the alice.add and bob.add to be indexed
-    setTimeout(function () {
-      sbot.phoenix.getNamesById(function (err, names) {
-        if (err) throw err
-        t.equal(names[sbot.feed.id], 'zed')
-        t.equal(names[alice.id],     '"alice"')
-        t.equal(names[bob.id],       'robert')
+    sbot.phoenix.getNamesById(function (err, names) {
+      if (err) throw err
+      t.equal(names[sbot.feed.id], 'zed')
+      t.equal(names[alice.id],     'alice')
+      t.equal(names[bob.id],       'robert')
 
-        sbot.phoenix.getIdsByName(function (err, ids) {
-          if (err) throw err
-          t.equal(ids['zed'],     sbot.feed.id)
-          t.equal(ids['"alice"'], alice.id)
-          t.equal(ids['robert'],  bob.id)
-          t.end()
-        })
+      sbot.phoenix.getIdsByName(function (err, ids) {
+        if (err) throw err
+        t.equal(ids['zed'],     sbot.feed.id)
+        t.equal(ids['alice'],   alice.id)
+        t.equal(ids['robert'],  bob.id)
+        t.end()
       })
-    }, 100)
+    })
+  })
+})
+
+tape('trust & names', function (t) {
+  var sbot = require('./util').newserver()
+
+  var alice = sbot.ssb.createFeed(ssbKeys.generate())
+  var bob   = sbot.ssb.createFeed(ssbKeys.generate())
+
+  var done = multicb()
+  schemas.addOwnName(sbot.feed, 'zed', done())
+  schemas.addOwnName(alice, 'alice', done())
+  schemas.addOwnName(bob, 'bob', done())
+  schemas.addTrust(sbot.feed, alice.id, 1, done())
+  done(function (err) {
+    if (err) throw err
+    var done = multicb({ pluck: 1 })
+    sbot.phoenix.getProfile(alice.id, done())
+    sbot.phoenix.getProfile(bob.id, done())
+    done(function (err, profiles) {
+      if (err) throw err
+      t.equal(profiles[0].trust, 1)
+      t.equal(profiles[1].trust, 0)
+      t.end()
+    })
   })
 })


### PR DESCRIPTION
When a user doesnt have a name assigned by the local user, falls back to a name by a trusted user before using the self-assigned name.
