### PR TITLE
fix: indexed messages not found in the db now emit null instead of error

### DIFF
--- a/index.js
+++ b/index.js
@@ -214,7 +214,19 @@ exports.init = function (sbot) {
         var done = multicb({ pluck: 1 })
         index
           .slice(start, end)
-          .forEach(function (v) { api.getMsg(v.key, done()) })
+          .forEach(function (v) {
+            var msgCb = done()
+            api.getMsg(v.key, function (err, msg) {
+              if (err) {
+                // suppress this error
+                // the message isnt in the local cache (yet)
+                // but it got into the index, likely due to a link
+                // instead of an error, we'll put a null there to indicate the gap
+                msg = { key: v.key, msg: null }
+              }
+              msgCb(null, msg)
+            })
+          })
         done(cb)
       })
     }

--- a/processor.js
+++ b/processor.js
@@ -202,7 +202,7 @@ module.exports = function(sbot, state) {
       try { process(msg) }
       catch (e) {
         // :TODO: use sbot logging plugin
-        console.warn('Failed to process message', e, msg)
+        console.error('Failed to process message', e, msg)
       }
     }
   }


### PR DESCRIPTION
if a message from `getPosts`, `getInbox`, and other index getters is not found, instead of an error response, you now receive a `{ key: <key>, msg: undefined }` in the output. this can happen when a message links to another message which isnt locally stored (yet)

this changes the output in a way that can break downstream, bumping major
