### PR TITLE
fix: id -> names mapping now uses trust to decide conflicts

### DIFF
--- a/processor.js
+++ b/processor.js
@@ -154,7 +154,7 @@ module.exports = function(sbot, state) {
       for (var id in profile.assignedBy) {
         if (profile.assignedBy[id].name && state.trustedProfiles[id]) {
           name = profile.assignedBy[id].name
-          trust = 1
+          trust = 0.5
           break
         }
       }
@@ -162,8 +162,13 @@ module.exports = function(sbot, state) {
 
     // store
     state.names[pid] = name
-    state.ids[name] = pid
-    state.nameTrustRanks[pid]  = trust
+    if (!state.ids[name])
+      state.ids[name] = pid
+    else {
+      if (trust >= state.nameTrustRanks[state.ids[name]])
+        state.ids[name] = pid
+    }
+    state.nameTrustRanks[pid] = trust
   }
 
   function rebuildNamesBy(pid) {


### PR DESCRIPTION
related to https://github.com/ssbc/phoenix/issues/283

currently, phoenix maintains a `name` to `id` map. this isnt an ideal decision because you can have multiple ids for a given name -- long run, we should change this structure

for now, this fix will use map the most trusted name to the id. it'll be up to the local user not to conflict names.
